### PR TITLE
Fixed non-string data types in text bug

### DIFF
--- a/quiz_reports.py
+++ b/quiz_reports.py
@@ -117,7 +117,7 @@ def main():
             lines += 1
 
             # add student response
-            text, lines, pdf = wrap_text_line(text, row[c], lines, pdf)
+            text, lines, pdf = wrap_text_line(text, str(row[c]), lines, pdf)
             pdf.drawText(text)
 
             # add page break for next question/response


### PR DESCRIPTION
# Would close #9 

* casting column values to string type before making pdfs 
* this removes any ambiguity around data types entering that field (as we saw some weird ones earlier like `float` and `NaN`
