### PR TITLE
Jupyter notebook execution instructions made more clear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .vscode
 .env
 __pycache__/
+.ipynb_checkpoints
+*.code-workspace
 
 
 # Keep following folders but not contents
@@ -9,5 +11,3 @@ raw_reports/*
 
 output/*
 !output/.gitkeep
-
-.ipynb_checkpoints

--- a/Quiz Reports.ipynb
+++ b/Quiz Reports.ipynb
@@ -6,6 +6,8 @@
    "source": [
     "# Quiz Reports\n",
     "\n",
+    "**To run, go to Kernal and select Restart and Run All**\n",
+    "\n",
     "## Summary\n",
     "\n",
     "**Quiz Reports** is a Jupyter Notebook and Python application that pulls quiz data from [Canvas LMS](https://github.com/instructure/canvas-lms) to create PDF documents containing student answers to *essay questions*. Application requires the following user inputs:\n",
@@ -48,8 +50,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1. Initialization\n",
-    "Run the following block of code to initialize python modules."
+    "## Initialization\n",
+    "The following block of code initializes python modules."
    ]
   },
   {
@@ -67,8 +69,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Get Quiz Reports PDFs\n",
-    "Run the block of code below. Input token, canvas instance, course id and quiz id when prompted.\n",
+    "## Get Quiz Reports PDFs\n",
+    "Input token, canvas instance, course id and quiz id when prompted.\n",
     "\n",
     "\n",
     "#### Canvas Instance URLS *(copy and paste from list when prompted):*\n",

--- a/src/interface.py
+++ b/src/interface.py
@@ -9,10 +9,10 @@ Wednesday, April 01, 2020
 """
 
 import getpass
-import settings
-from util import shut_down
 from canvasapi import Canvas
 from termcolor import cprint
+from util import shut_down
+import settings
 
 
 def get_user_inputs():

--- a/src/settings.py
+++ b/src/settings.py
@@ -7,7 +7,7 @@ authors:
 @markoprodanovic
 
 last edit:
-Wednesday, April 01, 2020
+Wednesday, April 03, 2020
 """
 
 


### PR DESCRIPTION
* Added line saying to select Kernal > Restart and Run All
* removed all language suggesting to run block separately
* removed section numbering so as to not suggest "steps" but rather a single command to execute
